### PR TITLE
Add intranet dashboard view and route

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class DashboardController extends Controller
+{
+    /**
+     * Display the intranet dashboard.
+     */
+    public function index()
+    {
+        return view('dashboard');
+    }
+}

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,0 +1,4 @@
+{
+  "resources/css/app.css": {"file": "app.css", "src": "resources/css/app.css"},
+  "resources/js/app.js": {"file": "app.js", "src": "resources/js/app.js", "isEntry": true}
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.app')
+
+@section('body')
+<div class="min-h-screen flex">
+    <!-- Sidebar -->
+    <div id="sidebar" class="bg-white w-64 space-y-6 py-7 px-2 absolute inset-y-0 left-0 transform -translate-x-full md:relative md:translate-x-0 transition duration-200 ease-in-out shadow-md">
+        <nav class="mt-10">
+            <a href="#" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100">
+                <!-- Home icon -->
+                <svg class="w-6 h-6 mr-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/></svg>
+                <span>Accueil</span>
+            </a>
+            <a href="#" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100">
+                <!-- Users icon -->
+                <svg class="w-6 h-6 mr-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z"/></svg>
+                <span>Utilisateurs</span>
+            </a>
+            <a href="#" class="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100">
+                <!-- Settings icon -->
+                <svg class="w-6 h-6 mr-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/></svg>
+                <span>Paramètres</span>
+            </a>
+        </nav>
+    </div>
+    <!-- Main content -->
+    <div class="flex-1 flex flex-col">
+        <header class="flex items-center justify-between bg-white shadow px-4 py-3">
+            <div class="flex items-center space-x-2">
+                <button id="menu-btn" class="text-gray-500 focus:outline-none md:hidden">
+                    <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"/></svg>
+                </button>
+                <h1 class="text-xl font-semibold">Tableau de bord</h1>
+            </div>
+        </header>
+        <main class="flex-1 p-4">
+            <p>Bienvenue sur votre intranet.</p>
+        </main>
+    </div>
+</div>
+<script>
+    const btn = document.getElementById('menu-btn');
+    const sidebar = document.getElementById('sidebar');
+    btn.addEventListener('click', () => {
+        sidebar.classList.toggle('-translate-x-full');
+    });
+</script>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>@yield('title', 'Dashboard')</title>
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="font-sans antialiased bg-gray-100">
+    @yield('body')
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,5 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\DashboardController;
 
 Route::get('/', [HomeController::class, 'index']);
+Route::get('/dashboard', [DashboardController::class, 'index']);

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -16,4 +16,11 @@ class ExampleTest extends TestCase
 
         $response->assertStatus(200);
     }
+
+    public function test_the_dashboard_route_is_accessible(): void
+    {
+        $response = $this->get('/dashboard');
+
+        $response->assertStatus(200);
+    }
 }


### PR DESCRIPTION
## Summary
- add a minimal layout using Tailwind CSS
- create `DashboardController` with index action
- create a responsive dashboard view with a collapsible sidebar and Heroicons
- register `/dashboard` route
- test the new route in ExampleTest
- add placeholder Vite manifest for tests

## Testing
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_68401866485c8324b226d79b2ffe2197