### PR TITLE
Add Order model, migration, seed and dashboard stats

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
-use Illuminate\Support\Facades\DB;
+use App\Models\Order;
 
 class DashboardController extends Controller
 {
@@ -12,8 +12,8 @@ class DashboardController extends Controller
         // Exemples de stats ; adaptez à votre schéma
         $stats = [
             'users'   => User::count(),
-            'orders'  => DB::table('orders')->count(),
-            'revenue' => DB::table('orders')->sum('total'),
+            'orders'  => Order::count(),
+            'revenue' => Order::sum('total'),
         ];
 
         // Données fictives pour un graphique (6 derniers mois)

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'total',
+    ];
+}

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Order>
+ */
+class OrderFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'total' => fake()->randomFloat(2, 10, 500),
+        ];
+    }
+}

--- a/database/migrations/2025_06_04_134100_create_orders_table.php
+++ b/database/migrations/2025_06_04_134100_create_orders_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('orders', function (Blueprint $table) {
+            $table->id();
+            $table->decimal('total', 10, 2);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('orders');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use App\Models\Order;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -19,5 +20,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        Order::factory()->count(5)->create();
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,5 +29,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="APP_KEY" value="base64:sLLdnWCiONCuTbyUxVcjhM2CWJ4IgfJUnWdc9Iollrg="/>
     </php>
 </phpunit>

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,11 +2,12 @@
 
 namespace Tests\Feature;
 
-// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
 {
+    use RefreshDatabase;
     /**
      * A basic test example.
      */
@@ -22,5 +23,18 @@ class ExampleTest extends TestCase
         $response = $this->get('/dashboard');
 
         $response->assertStatus(200);
+    }
+
+    public function test_dashboard_displays_order_stats(): void
+    {
+        $orders = \App\Models\Order::factory()->count(3)->create([
+            'total' => 100,
+        ]);
+
+        $response = $this->get('/dashboard');
+
+        $response->assertStatus(200);
+        $response->assertSee('3');
+        $response->assertSee('300');
     }
 }


### PR DESCRIPTION
## Summary
- add orders table migration
- generate Order model and factory
- seed demo orders
- compute order counts and revenue in DashboardController
- extend example feature tests to cover order totals
- set APP_KEY for tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_68404c9de660832496fdbbe19e161046