### PR TITLE
Add dashboard JS entry to Vite config

### DIFF
--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -9,5 +9,11 @@
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true
+  },
+  "resources/js/dashboard.js": {
+    "file": "assets/dashboard-Bd4UDWH_.js",
+    "name": "dashboard",
+    "src": "resources/js/dashboard.js",
+    "isEntry": true
   }
 }

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -5,7 +5,7 @@
     <title>@yield('title', 'Dashboard')</title>
 
     {{-- CSS & JS compilés par Vite --}}
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @vite(['resources/css/app.css', 'resources/js/app.js', 'resources/js/dashboard.js'])
 </head>
 <body class="bg-gray-100 font-sans antialiased">
     @include('partials.nav')

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,11 @@ import laravel from 'laravel-vite-plugin';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: [
+                'resources/css/app.css',
+                'resources/js/app.js',
+                'resources/js/dashboard.js',
+            ],
             refresh: true,
         }),
     ],


### PR DESCRIPTION
## Summary
- register `resources/js/dashboard.js` as a Vite entry
- include the dashboard script in the base layout
- update Vite manifest

## Testing
- `npm run build`
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68404e573504832496fb6b1139f4c526