### PR TITLE
Add controller and db tests

### DIFF
--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Order;
+use App\Models\User;
+
+class DashboardControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dashboard_view_receives_stats_and_sales(): void
+    {
+        Order::factory()->count(2)->create();
+        User::factory()->create();
+
+        $response = $this->get('/dashboard');
+
+        $response->assertStatus(200);
+        $response->assertViewIs('dashboard');
+        $response->assertViewHasAll(['stats', 'sales']);
+    }
+}

--- a/tests/Feature/OrderDatabaseTest.php
+++ b/tests/Feature/OrderDatabaseTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Order;
+
+class OrderDatabaseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_persist_orders_to_database(): void
+    {
+        Order::factory()->create(['total' => 123.45]);
+
+        $this->assertDatabaseHas('orders', [
+            'total' => 123.45,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add dashboard controller feature test
- add order DB test

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_68404fdf636083249f0b38480835f2d5