### PR TITLE
Add home route and secure dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ APP_KEY=
 APP_DEBUG=false
 APP_URL=http://localhost
 
+# Toggle the temporary admin assignment route
+ENABLE_ADMIN_ASSIGN_TEMP=false
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,15 +10,8 @@ use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
-    use HasRoles;
-    // ...
-}
-
-
-class User extends Authenticatable
-{
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,16 +1,26 @@
 <?php
-use Illuminate\Support\Facades\Route;
 
-// Route temporaire pour assigner le rôle "admin" à l'utilisateur ID=1
-Route::get('/assign-admin-temp', function () {
-    $user = User::find(1);
-    if (! $user) {
-        return "L'utilisateur ID=1 n'existe pas";
-    }
-    // Vérifie si l'utilisateur n'a pas déjà le rôle
-    if ($user->hasRole('admin')) {
-        return "L'utilisateur ID=1 a déjà le rôle \"admin\"";
-    }
-    $user->assignRole('admin');
-    return "Le rôle \"admin\" a bien été attribué à l'utilisateur ID=1";
+use Illuminate\Support\Facades\Route;
+use App\Models\User;
+
+Route::view('/', 'welcome')->name('home');
+
+Route::middleware('auth')->group(function () {
+    Route::view('/dashboard', 'dashboard')->name('dashboard');
 });
+
+if (env('ENABLE_ADMIN_ASSIGN_TEMP', false)) {
+    // Route temporaire pour assigner le rôle "admin" à l'utilisateur ID=1
+    Route::get('/assign-admin-temp', function () {
+        $user = User::find(1);
+        if (! $user) {
+            return "L'utilisateur ID=1 n'existe pas";
+        }
+        // Vérifie si l'utilisateur n'a pas déjà le rôle
+        if ($user->hasRole('admin')) {
+            return "L'utilisateur ID=1 a déjà le rôle \"admin\"";
+        }
+        $user->assignRole('admin');
+        return "Le rôle \"admin\" a bien été attribué à l'utilisateur ID=1";
+    });
+}


### PR DESCRIPTION
## Summary
- add ENABLE_ADMIN_ASSIGN_TEMP environment variable
- secure admin assignment route with feature flag
- register root route returning the welcome page
- add /dashboard route protected by auth
- fix duplicate user model declaration

## Testing
- `composer install`
- `php artisan key:generate`
- `./vendor/bin/phpunit` *(fails: Route [verification.verify] not defined, 2 errors, 23 failures)*

------
https://chatgpt.com/codex/tasks/task_b_68416570f4b88324a318acf0d81854ce