### PR TITLE
Add API routes

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
+    return $request->user();
+});


### PR DESCRIPTION
## Summary
- add standard Laravel API routes
- register the new routes in `bootstrap/app.php`

## Testing
- `composer test` *(fails: 25 failed, 3 warnings, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_b_684168edf4c88324bc56bd489fb29446