### PR TITLE
Enable debug in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
-APP_DEBUG=false
+APP_DEBUG=true
 APP_URL=http://localhost
 
 # Toggle the temporary admin assignment route


### PR DESCRIPTION
## Summary
- fix .env.example APP_DEBUG to true

## Testing
- `composer install`
- `cp .env.example .env`
- `php artisan key:generate`
- `./vendor/bin/phpunit` *(fails: Route [verification.verify] not defined)*

------
https://chatgpt.com/codex/tasks/task_b_684169cf6c98832493022671806fd2a3