### PR TITLE
Harden temporary admin route

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Run the test suite with:
 composer test
 ```
 
+## Security
+
+`ENABLE_ADMIN_ASSIGN_TEMP` enables a temporary route, `/assign-admin-temp`,
+which grants the `admin` role to the user with ID=1. The route is protected by
+the `auth` middleware but should be used only for local setup. Do **not**
+enable this flag in production. If still required, add further protections or
+remove the route before deploying.
+
 ## License
 
 This project is open-sourced software licensed under the MIT license.

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,7 +11,7 @@ Route::middleware('auth')->group(function () {
 
 if (env('ENABLE_ADMIN_ASSIGN_TEMP', false)) {
     // Route temporaire pour assigner le rôle "admin" à l'utilisateur ID=1
-    Route::get('/assign-admin-temp', function () {
+    Route::middleware('auth')->get('/assign-admin-temp', function () {
         $user = User::find(1);
         if (! $user) {
             return "L'utilisateur ID=1 n'existe pas";


### PR DESCRIPTION
## Summary
- secure temporary admin route with auth middleware
- document ENABLE_ADMIN_ASSIGN_TEMP and warn against production use

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6841b86a5a688324b89b5f3ac4ca5425