### PR TITLE
Add README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,61 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Open Laravel
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+This repository contains a basic Laravel application. Follow the steps below to get a local copy running and learn how to deploy it with cPanel.
 
-## About Laravel
+## Cloning the Repository
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+```bash
+git clone <repository-url>
+cd open-laravel
+```
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+Replace `<repository-url>` with the URL of your git repository.
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+## Installing Dependencies
 
-## Learning Laravel
+Make sure you have PHP and [Composer](https://getcomposer.org/) installed. Then run:
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+```bash
+composer install
+```
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+## Setting Up Environment Variables
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+1. Copy the example environment file:
 
-## Laravel Sponsors
+   ```bash
+   cp .env.example .env
+   ```
+2. Edit `.env` and update the database credentials and any other settings you need.
+3. Generate the application key:
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+   ```bash
+   php artisan key:generate
+   ```
 
-### Premium Partners
+## Running Migrations
 
-- **[Vehikl](https://vehikl.com)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Redberry](https://redberry.international/laravel-development)**
-- **[Active Logic](https://activelogic.com)**
+After configuring the database in your `.env`, run the migrations:
 
-## Contributing
+```bash
+php artisan migrate
+```
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+## Deploying with cPanel
 
-## Code of Conduct
+This project includes a `.cpanel.yml` file for automated deployments. Typical steps are:
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+1. On your cPanel account, create a Git Version Control repository and point it to your repo.
+2. Ensure the document root of your domain or subdomain points to the `public` directory of the project.
+3. After each push, cPanel will run the commands defined in `.cpanel.yml`, which include `composer install`, caching commands and migrations.
+4. If automatic deployment is disabled, you can trigger it from the cPanel interface.
 
-## Security Vulnerabilities
+## Troubleshooting
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+- Run `php artisan config:clear` and `php artisan cache:clear` if configuration changes are not taking effect.
+- Check `storage/logs/laravel.log` for error messages.
+- Make sure the `storage` and `bootstrap/cache` directories are writable by the web server.
+- If migrations fail during deployment, verify your database credentials and permissions.
 
-## License
+For additional help, refer to the [Laravel documentation](https://laravel.com/docs) and your hosting provider's guides on using cPanel with Git.
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
## Summary
- replace Laravel default README with repository setup guide

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68429871ebec8324b90e67e3fae647a6