### PR TITLE
Remove menu icons

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -29,9 +29,6 @@
     <button onclick="document.getElementById('dropdownMenu').classList.toggle('hidden')"
         class="flex items-center px-3 py-2 rounded-md text-gray-700 bg-gray-100 hover:bg-gray-200">
         {{ Auth::user()->name }}
-        <svg class="ml-1 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-        </svg>
     </button>
     <div id="dropdownMenu" class="absolute right-0 mt-2 w-48 bg-white border border-gray-200 rounded-xl shadow-lg py-2 hidden z-50">
         <div class="px-4 py-2 font-semibold text-gray-900">{{ Auth::user()->name }}</div>
@@ -51,10 +48,7 @@
             <!-- Hamburger -->
             <div class="-me-2 flex items-center sm:hidden">
                 <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
-                    <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
-                        <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                        <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
+                    <span class="sr-only">Menu</span>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- clean up navigation menu visuals by removing arrow icon in user dropdown and burger icon in mobile header

## Testing
- `composer install --no-scripts`
- `./vendor/bin/phpunit` *(fails: MissingAppKeyException / PDOException)*

------
https://chatgpt.com/codex/tasks/task_b_684985d2a1dc832492af7e211c3ee409