### PR TITLE
Add conversations and messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Ce projet est un intranet minimaliste, moderne, sécurisé et évolutif, dévelo
 - **Authentification** (login uniquement : seul l’admin peut créer des comptes via Tinker ou migration)
 - **Partage et gestion de fichiers** (upload, téléchargement, suppression, listing)
 - **Intégration IA** (envoi de fichier à OpenAI, résumé automatisé, mini-playground)
+- **Conversations privées** (discussions avec fichiers joints et analyse IA)
 - **Mini-dashboard dynamique** (statistiques clés, derniers fichiers, liens rapides)
 - **Design responsive & minimaliste** (Tailwind CSS, Dark/Light facile à modifier)
 - **Déploiement facile sur Codespaces & cPanel**

--- a/app/Http/Controllers/ConversationController.php
+++ b/app/Http/Controllers/ConversationController.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\MessageAttachment;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Smalot\PdfParser\Parser;
+
+class ConversationController extends Controller
+{
+    public function index()
+    {
+        if (auth()->user()->is_admin) {
+            $conversations = Conversation::orderBy('created_at', 'desc')->paginate(10);
+        } else {
+            $conversations = Conversation::where('user_id', auth()->id())
+                ->orderBy('created_at', 'desc')
+                ->paginate(10);
+        }
+        return view('conversations.index', compact('conversations'));
+    }
+
+    public function create()
+    {
+        return view('conversations.create');
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'title' => 'required|string|max:255',
+        ]);
+
+        Conversation::create([
+            'user_id' => auth()->id(),
+            'title' => $request->title,
+        ]);
+
+        return redirect()->route('conversations.index')->with('success', 'Conversation créée');
+    }
+
+    public function show($id)
+    {
+        $conversation = Conversation::findOrFail($id);
+
+        if ($conversation->user_id !== auth()->id() && !auth()->user()->is_admin) {
+            abort(403);
+        }
+
+        $messages = $conversation->messages()->with('user', 'attachments')->orderBy('created_at')->get();
+
+        return view('conversations.show', compact('conversation', 'messages'));
+    }
+
+    public function storeMessage(Request $request, $id)
+    {
+        $conversation = Conversation::findOrFail($id);
+
+        if ($conversation->user_id !== auth()->id() && !auth()->user()->is_admin) {
+            abort(403);
+        }
+
+        $request->validate([
+            'content' => 'required|string',
+            'attachments.*' => 'file|mimes:pdf,doc,docx,txt,jpg,png|max:10240',
+        ]);
+
+        $message = $conversation->messages()->create([
+            'user_id' => auth()->id(),
+            'content' => $request->content,
+        ]);
+
+        if ($request->hasFile('attachments')) {
+            foreach ($request->file('attachments') as $file) {
+                $filename = time() . '_' . $file->getClientOriginalName();
+                $path = $file->storeAs('', $filename, 'private');
+                $message->attachments()->create([
+                    'filename' => $file->getClientOriginalName(),
+                    'path' => $path,
+                ]);
+            }
+        }
+
+        return redirect()->route('conversations.show', $conversation->id);
+    }
+
+    public function analyzeAttachment($id)
+    {
+        $attachment = MessageAttachment::findOrFail($id);
+        $conversation = $attachment->message->conversation;
+
+        if ($conversation->user_id !== auth()->id() && !auth()->user()->is_admin) {
+            abort(403);
+        }
+
+        if ($attachment->analysis_json) {
+            $extracted = json_decode($attachment->analysis_json, true);
+            $answer = $attachment->analysis_raw ?? '';
+            return view('conversations.analyze', [
+                'attachment' => $attachment,
+                'analysis' => $answer,
+                'extracted' => $extracted,
+            ]);
+        }
+
+        $filePath = Storage::disk('private')->path($attachment->path);
+        $text = null;
+
+        if (Str::endsWith($attachment->filename, '.txt')) {
+            $text = file_get_contents($filePath);
+        } elseif (Str::endsWith($attachment->filename, '.pdf')) {
+            try {
+                $parser = new Parser();
+                $pdf = $parser->parseFile($filePath);
+                $text = $pdf->getText();
+            } catch (\Exception $e) {
+                return back()->with('error', 'Impossible de lire ce PDF.');
+            }
+        } else {
+            return back()->with('error', 'Ce type de fichier n’est pas encore supporté.');
+        }
+
+        $text = mb_substr($text, 0, 3000);
+
+        $apiKey = env('OPENAI_API_KEY');
+        $prompt = "Voici le contenu d'un document.\n\n$text\n\nPeux-tu en faire un résumé ?";
+
+        $response = Http::withToken($apiKey)
+            ->post('https://api.openai.com/v1/chat/completions', [
+                'model' => 'gpt-3.5-turbo',
+                'messages' => [
+                    ['role' => 'user', 'content' => $prompt],
+                ],
+                'max_tokens' => 400,
+            ]);
+
+        $body = $response->json();
+        $answer = $body['choices'][0]['message']['content'] ?? 'Pas de réponse.';
+
+        $extracted = null;
+        try {
+            $extracted = json_decode($answer, true);
+            if (!$extracted) {
+                $jsonStart = strpos($answer, '{');
+                if ($jsonStart !== false) {
+                    $jsonString = substr($answer, $jsonStart);
+                    $extracted = json_decode($jsonString, true);
+                }
+            }
+        } catch (\Exception $e) {
+            $extracted = null;
+        }
+
+        $attachment->analysis_json = $extracted ? json_encode($extracted) : null;
+        $attachment->analysis_raw = $answer;
+        $attachment->save();
+
+        return view('conversations.analyze', [
+            'attachment' => $attachment,
+            'analysis' => $answer,
+            'extracted' => $extracted,
+        ]);
+    }
+}

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Conversation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function messages()
+    {
+        return $this->hasMany(Message::class);
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Message extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'conversation_id',
+        'user_id',
+        'content',
+    ];
+
+    public function conversation()
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function attachments()
+    {
+        return $this->hasMany(MessageAttachment::class);
+    }
+}

--- a/app/Models/MessageAttachment.php
+++ b/app/Models/MessageAttachment.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MessageAttachment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'message_id',
+        'filename',
+        'path',
+        'analysis_json',
+        'analysis_raw',
+    ];
+
+    public function message()
+    {
+        return $this->belongsTo(Message::class);
+    }
+}

--- a/database/migrations/2025_06_13_000000_create_conversations_table.php
+++ b/database/migrations/2025_06_13_000000_create_conversations_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('conversations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('conversations');
+    }
+};

--- a/database/migrations/2025_06_13_010000_create_messages_table.php
+++ b/database/migrations/2025_06_13_010000_create_messages_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('conversation_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/database/migrations/2025_06_13_020000_create_message_attachments_table.php
+++ b/database/migrations/2025_06_13_020000_create_message_attachments_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('message_attachments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('message_id')->constrained()->onDelete('cascade');
+            $table->string('filename');
+            $table->string('path');
+            $table->json('analysis_json')->nullable();
+            $table->text('analysis_raw')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('message_attachments');
+    }
+};

--- a/resources/views/conversations/analyze.blade.php
+++ b/resources/views/conversations/analyze.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-2xl mx-auto p-4">
+    <h1 class="text-2xl font-semibold mb-4">Analyse OpenAI du fichier : {{ $attachment->filename }}</h1>
+
+    @if($extracted)
+        <div class="mb-4">
+            <strong>Champs extraits :</strong>
+            <table class="w-full bg-white border border-gray-300 rounded mt-2 mb-6">
+                <tbody>
+                @foreach($extracted as $key => $value)
+                    <tr class="border-b">
+                        <th class="text-left px-3 py-2 bg-gray-100 w-1/3 capitalize">
+                            {{ str_replace('_', ' ', $key) }}
+                        </th>
+                        <td class="px-3 py-2">
+                            {{ is_array($value) ? implode(', ', $value) : $value }}
+                        </td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        </div>
+    @else
+        <div class="mb-4">
+            <strong>Résumé/Analyse brute :</strong>
+            <div class="bg-gray-100 p-3 rounded mt-2">
+                {{ $analysis }}
+            </div>
+        </div>
+    @endif
+
+    <a href="{{ url()->previous() }}" class="text-blue-600 hover:underline">Retour</a>
+</div>
+@endsection

--- a/resources/views/conversations/create.blade.php
+++ b/resources/views/conversations/create.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-md mx-auto bg-white p-6 rounded-2xl shadow mt-6">
+    <h1 class="text-2xl font-bold mb-6 text-blue-700">Nouvelle conversation</h1>
+    <form action="{{ route('conversations.store') }}" method="POST">
+        @csrf
+        <div class="mb-4">
+            <input type="text" name="title" class="w-full border rounded-xl px-3 py-2" placeholder="Titre de la conversation" required>
+            @error('title')
+                <p class="text-red-500 text-sm">{{ $message }}</p>
+            @enderror
+        </div>
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-xl">Créer</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/conversations/index.blade.php
+++ b/resources/views/conversations/index.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-4xl mx-auto bg-white p-6 rounded-2xl shadow mt-6">
+    <h1 class="text-3xl font-bold mb-6 text-blue-700">Conversations</h1>
+    <a href="{{ route('conversations.create') }}" class="bg-blue-600 text-white px-4 py-2 rounded-xl mb-4 inline-block">Nouvelle conversation</a>
+    <ul class="divide-y divide-gray-200">
+        @foreach($conversations as $conversation)
+            <li class="py-4">
+                <a href="{{ route('conversations.show', $conversation->id) }}" class="text-lg text-blue-600 hover:underline">
+                    {{ $conversation->title }}
+                </a>
+            </li>
+        @endforeach
+    </ul>
+</div>
+@endsection

--- a/resources/views/conversations/show.blade.php
+++ b/resources/views/conversations/show.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="max-w-4xl mx-auto p-6 bg-white rounded-2xl shadow mt-6">
+    <h1 class="text-2xl font-bold mb-4">{{ $conversation->title }}</h1>
+    <div class="space-y-4 mb-8">
+        @foreach($messages as $message)
+            <div class="border rounded-xl p-4">
+                <div class="text-sm text-gray-500 mb-2">{{ $message->user->name }} - {{ $message->created_at->format('d/m/Y H:i') }}</div>
+                <p class="mb-2">{{ $message->content }}</p>
+                @if($message->attachments->count())
+                    <ul class="list-disc ms-5">
+                        @foreach($message->attachments as $att)
+                            <li>
+                                {{ $att->filename }}
+                                @if(!$att->analysis_json)
+                                    <a href="{{ route('attachments.analyze', $att->id) }}" class="text-purple-600 hover:underline ms-2">Analyser</a>
+                                @else
+                                    <a href="{{ route('attachments.analyze', $att->id) }}" class="text-green-600 hover:underline ms-2">Voir analyse</a>
+                                @endif
+                            </li>
+                        @endforeach
+                    </ul>
+                @endif
+            </div>
+        @endforeach
+    </div>
+
+    <form action="{{ route('conversations.message.store', $conversation->id) }}" method="POST" enctype="multipart/form-data">
+        @csrf
+        <textarea name="content" rows="3" class="w-full border rounded-xl px-3 py-2 mb-3" placeholder="Votre message..." required></textarea>
+        @error('content')
+            <p class="text-red-500 text-sm">{{ $message }}</p>
+        @enderror
+        <input type="file" name="attachments[]" multiple class="border mb-3">
+        @error('attachments.*')
+            <p class="text-red-500 text-sm">{{ $message }}</p>
+        @enderror
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-xl">Envoyer</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -21,6 +21,9 @@
                     <x-nav-link :href="route('openai.index')" :active="request()->routeIs('openai.index')">
                         OpenAI Playground
                     </x-nav-link>
+                    <x-nav-link :href="route('conversations.index')" :active="request()->routeIs('conversations.*')">
+                        Conversations
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -65,6 +68,9 @@
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('openai.index')" :active="request()->routeIs('openai.index')">
                 OpenAI Playground
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('conversations.index')" :active="request()->routeIs('conversations.*')">
+                Conversations
             </x-responsive-nav-link>
         </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\FileShareController;
 use App\Http\Controllers\OpenAIController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\ConversationController;
 
 // (Décommente si tu ajoutes un vrai contrôleur d’admin)
 // use App\Http\Controllers\Admin\AdminDashboardController;
@@ -47,6 +48,14 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/files/analyze/{id}', [FileShareController::class, 'analyze'])->name('files.analyze');
     Route::get('/openai', [OpenAIController::class, 'index'])->name('openai.index');
     Route::post('/openai', [OpenAIController::class, 'send'])->name('openai.send');
+
+    // Conversations
+    Route::get('/conversations', [ConversationController::class, 'index'])->name('conversations.index');
+    Route::get('/conversations/create', [ConversationController::class, 'create'])->name('conversations.create');
+    Route::post('/conversations', [ConversationController::class, 'store'])->name('conversations.store');
+    Route::get('/conversations/{id}', [ConversationController::class, 'show'])->name('conversations.show');
+    Route::post('/conversations/{id}/messages', [ConversationController::class, 'storeMessage'])->name('conversations.message.store');
+    Route::get('/attachments/analyze/{id}', [ConversationController::class, 'analyzeAttachment'])->name('attachments.analyze');
 });
 
 // ===============================

--- a/tests/Feature/ConversationTest.php
+++ b/tests/Feature/ConversationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Conversation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class ConversationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_create_conversation()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/conversations', [
+            'title' => 'Test Conversation',
+        ]);
+
+        $response->assertRedirect('/conversations');
+        $this->assertDatabaseHas('conversations', [
+            'title' => 'Test Conversation',
+            'user_id' => $user->id,
+        ]);
+    }
+
+    public function test_user_can_post_message_with_file()
+    {
+        Storage::fake('private');
+        $user = User::factory()->create();
+        $conversation = Conversation::create(['user_id' => $user->id, 'title' => 'Chat']);
+
+        $file = UploadedFile::fake()->create('test.txt', 10);
+
+        $response = $this->actingAs($user)->post("/conversations/{$conversation->id}/messages", [
+            'content' => 'hello',
+            'attachments' => [$file],
+        ]);
+
+        $response->assertRedirect("/conversations/{$conversation->id}");
+        $this->assertDatabaseHas('messages', ['conversation_id' => $conversation->id, 'content' => 'hello']);
+        $this->assertDatabaseCount('message_attachments', 1);
+    }
+}


### PR DESCRIPTION
## Summary
- create Conversation, Message, and MessageAttachment models with migrations
- implement ConversationController with message posting and OpenAI analysis
- add conversation views and navigation links
- register conversation routes
- add feature tests and update docs

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849886f99908324b1ff70ebb5dc7b0a